### PR TITLE
nu@0.95.0: Fix removed dataframe feature

### DIFF
--- a/bucket/nu.json
+++ b/bucket/nu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.93.0",
+    "version": "0.95.0",
     "description": "A modern shell written in Rust",
     "homepage": "https://www.nushell.sh",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/nushell/nushell/releases/download/0.93.0/nu-0.93.0-x86_64-windows-msvc-full.zip",
-            "hash": "af75eff52af33ddfef77a5ec942216e3faafde111aaad4ccee36718765eb8953"
+            "url": "https://github.com/nushell/nushell/releases/download/0.95.0/nu-0.95.0-x86_64-pc-windows-msvc.zip",
+            "hash": "85c66c340e4b0d7239f346887513555c56c4c332c7d03a2d445283f330e38f28"
         },
         "arm64": {
-            "url": "https://github.com/nushell/nushell/releases/download/0.93.0/nu-0.93.0-aarch64-windows-msvc-full.zip",
-            "hash": "68735be2d35da8a50d6a703c0cda5108c29e69a95b576c0e62b8bb557e697aa4"
+            "url": "https://github.com/nushell/nushell/releases/download/0.95.0/nu-0.95.0-aarch64-pc-windows-msvc.zip",
+            "hash": "1b4f752f5df874f4bbc794d77a22170e4c98141201c61489edbba0edb084fb81"
         }
     },
     "bin": "nu.exe",
@@ -20,10 +20,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/nushell/nushell/releases/download/$version/nu-$version-x86_64-windows-msvc-full.zip"
+                "url": "https://github.com/nushell/nushell/releases/download/$version/nu-$version-x86_64-pc-windows-msvc.zip"
             },
             "arm64": {
-                "url": "https://github.com/nushell/nushell/releases/download/$version/nu-$version-aarch64-windows-msvc-full.zip"
+                "url": "https://github.com/nushell/nushell/releases/download/$version/nu-$version-aarch64-pc-windows-msvc.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The dataframe feature was removed on 0.94.0. To reinstate this feature, use the polars plugin
See https://github.com/nushell/nushell/commit/905e3d0715ad82fbf837e059ad7cd5184ea77f89
See https://www.nushell.sh/book/plugins.html for information on how to install plugins
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5894

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
